### PR TITLE
skip CSRF token verification for DonationsController#update

### DIFF
--- a/app/controllers/boostify/donations_controller.rb
+++ b/app/controllers/boostify/donations_controller.rb
@@ -5,6 +5,7 @@ module Boostify
     respond_to :html, except: :update
     respond_to :json, only: :update
 
+    skip_before_filter :verify_authenticity_token, only: :update
     before_filter :verify_signature!, only: :update
 
     def new


### PR DESCRIPTION
sender verification is already handled by HMAC signatures